### PR TITLE
Never pass null to Reflect.construct

### DIFF
--- a/app/scripts/injectors/constructor-injector.js
+++ b/app/scripts/injectors/constructor-injector.js
@@ -20,7 +20,7 @@ export default class ConstructorInjector extends Injector {
      */
     inject(dep) {
         let allDeps = super.inject(dep);
-        let args = allDeps ? allDeps.map((d) => d.injected) : null;
+        let args = allDeps ? allDeps.map((d) => d.injected) : [];
 
         if (dep.args) {
             args = args.concat(dep.args) || dep.args;


### PR DESCRIPTION
Passing null to Reflect.construct fails in less lenient browsers. This pull request should fix issue https://github.com/dryajov/opium/issues/1